### PR TITLE
Adds embed toggle for all internal links on a line

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -51,7 +51,7 @@ export default class HotkeysPlus extends Plugin {
 
     this.addCommand({
       id: "toggle-embed",
-      name: "Toggle link on line to embed",
+      name: "Toggle line to embed internal links",
       callback: () => this.toggleEmbed(),
       hotkeys: [
         {

--- a/main.ts
+++ b/main.ts
@@ -48,6 +48,18 @@ export default class HotkeysPlus extends Plugin {
         },
       ],
     });
+
+    this.addCommand({
+      id: "toggle-embed",
+      name: "Toggle link on line to embed",
+      callback: () => this.toggleEmbed(),
+      hotkeys: [
+        {
+          modifiers: ["Mod", "Shift"],
+          key: "1",
+        },
+      ],
+    });
   }
 
   onunload() {
@@ -122,6 +134,11 @@ export default class HotkeysPlus extends Plugin {
     return this.toggleElement(re, this.replaceBlockQuote);
   }
 
+  toggleEmbed() {
+    var re = /\S*\[\[/gim;
+      return this.toggleElement(re, this.replaceEmbed);
+  }
+
   replaceListElement(startText: string) {
     if (startText === "- ") {
       return "1. ";
@@ -141,6 +158,18 @@ export default class HotkeysPlus extends Plugin {
       return "> ";
     } else {
       return "> ";
+    }
+  }
+
+  replaceEmbed(startText: string) {
+    if (startText === "![[") {
+      return "[[";
+    }
+    else if (startText === "[[") {
+        return "![[";
+    }
+    else {
+        return "";
     }
   }
 


### PR DESCRIPTION
Adds feature for #2 with all internal links being updated.

Default hotkey is `Ctrl`/`Cmd` + `Shift` + `1`.

A further improvement could be made to add a setting to replace all matches (current functionality) or just the first match.