### PR TITLE
Add Command to remove line breaks & trim selected content

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -64,7 +64,7 @@ export default class HotkeysPlus extends Plugin {
     });
     this.addCommand({
       id: "clean-selected",
-      name: "Removes new line characters and html elements",
+      name: "Trims selected text and removes new line characters.",
       callback: () => this.cleanSelected(),
     });
 
@@ -118,11 +118,7 @@ export default class HotkeysPlus extends Plugin {
 		var activeLeaf: any = this.app.workspace.activeLeaf;
 		var editor = activeLeaf.view.sourceMode.cmEditor;
     var selectedText = this.getSelectedText(editor);
-    // removing new line chars
     var newString = selectedText.content.trim().replace(/(\r\n|\n|\r)/gm, ' ');
-    //removing html
-    newString = newString.replace(/<\/?\w+\/?>/gm, ' ');
-    // removing access white space
     newString = newString.replace(/  +/gm, ' ');
 		editor.replaceRange(newString, selectedText.start, selectedText.end);
 	}

--- a/main.ts
+++ b/main.ts
@@ -62,6 +62,11 @@ export default class HotkeysPlus extends Plugin {
       name: "Duplicate the current line or selected lines",
       callback: () => this.duplicateLines(),
     });
+    this.addCommand({
+      id: "clean-selected",
+      name: "Removes new line characters and html elements",
+      callback: () => this.cleanSelected(),
+    });
 
     this.addCommand({
       id: 'insert-line-above',
@@ -109,6 +114,18 @@ export default class HotkeysPlus extends Plugin {
     var newString = selectedText.content + "\n";
     editor.replaceRange(newString, selectedText.start, selectedText.start);
   }
+  cleanSelected() {
+		var activeLeaf: any = this.app.workspace.activeLeaf;
+		var editor = activeLeaf.view.sourceMode.cmEditor;
+    var selectedText = this.getSelectedText(editor);
+    // removing new line chars
+    var newString = selectedText.content.trim().replace(/(\r\n|\n|\r)/gm, ' ');
+    //removing html
+    newString = newString.replace(/<\/?\w+\/?>/gm, ' ');
+    // removing access white space
+    newString = newString.replace(/  +/gm, ' ');
+		editor.replaceRange(newString, selectedText.start, selectedText.end);
+	}
 
   onunload() {
     console.log("Unloading Hotkeys++ plugin");


### PR DESCRIPTION
Hey,

Looks like my formatter did screwed something up, not sure how to avoid that... Anyways, line 62 just trims the selected text and removes all line breaks.

I do a lot of copying from PDFs and line breaks are a real issue. Im thinking this could be extended to removing HTML as well, maybe even markdown.

For those of us that at some point want to remove all formatting from text.

PS: This is my first attempt at contributing so sorry if I messed something up.