### PR TITLE
Feature: Add "Copy line(s) up" (and rename "duplicate line" to "Copy line(s) down")

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains a few shortcuts that I use with [Obsidian](https://obsi
 | <kbd>Ctrl</kbd> + <kbd><</kbd>                    | Toggle blockquotes.                         |                                             |
 | <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>1</kbd> | Toggle embeds for internal links.           | [lynchjames](https://github.com/lynchjames) |
 | Blank by default                                  | Copy line(s) down                           | [NomarCub](https://github.com/NomarCub)     |
-| Blank by default                                  | Copy line(s) up                             | [tzarick](https://github.com/tzarick)     |
+| Blank by default                                  | Copy line(s) up                             | [tzarick](https://github.com/tzarick)       |
 | Blank by default                                  | Insert line below/above current line        | [Vinzent](https://github.com/Vinzent03)     |
 | Blank by default                                  | clear current line                          | [renmu123](https://github.com/renmu123)     |
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This repository contains a few shortcuts that I use with [Obsidian](https://obsi
 | <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>M</kbd> | Toggle between ordered and unordered lists. |                                             |
 | <kbd>Ctrl</kbd> + <kbd><</kbd>                    | Toggle blockquotes.                         |                                             |
 | <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>1</kbd> | Toggle embeds for internal links.           | [lynchjames](https://github.com/lynchjames) |
-| Blank by default                                  | Duplicate current line or selected lines    | [NomarCub](https://github.com/NomarCub)     |
+| Blank by default                                  | Copy line(s) down                           | [NomarCub](https://github.com/NomarCub)     |
+| Blank by default                                  | Copy line(s) up                             | [tzarick](https://github.com/tzarick)     |
 | Blank by default                                  | Insert line below/above current line        | [Vinzent](https://github.com/Vinzent03)     |
 | Blank by default                                  | clear current line                          | [renmu123](https://github.com/renmu123)     |
 

--- a/main.ts
+++ b/main.ts
@@ -5,7 +5,10 @@ import {
 } from "obsidian";
 
 export default class HotkeysPlus extends Plugin {
-  onInit() { }
+  onInit() {
+    console.log('INITITING');
+    console.log('ok')
+   }
 
   onload() {
     console.log("Loading Hotkeys++ plugin");
@@ -59,10 +62,17 @@ export default class HotkeysPlus extends Plugin {
     });
 
     this.addCommand({
-      id: "duplicate-lines",
-      name: "Duplicate the current line or selected lines",
-      callback: () => this.duplicateLines(),
+      id: "duplicate-lines-down",
+      name: "Copy line or lines down",
+      callback: () => this.duplicateLines("below"),
     });
+
+    this.addCommand({
+      id: "duplicate-lines-up",
+      name: "Copy line or lines up",
+      callback: () => this.duplicateLines("above"),
+    });
+
     this.addCommand({
       id: "clean-selected",
       name: "Trims selected text and removes new line characters.",
@@ -126,14 +136,24 @@ export default class HotkeysPlus extends Plugin {
     }
   }
 
-  duplicateLines(): void {
+  duplicateLines(mode: "above" | "below"): void {
     const view = this.app.workspace.getActiveViewOfType(MarkdownView);
     if (!view) return;
 
     const editor = view.editor;
     const selectedText = this.getSelectedText(editor);
     const newString = selectedText.content + "\n";
-    editor.replaceRange(newString, selectedText.start, selectedText.start);
+    
+    if (mode === "below") {
+      editor.replaceRange(newString, selectedText.start, selectedText.start);
+    }
+    else {
+      const nextLineStart = {
+        ...selectedText.start,
+        line: selectedText.start.line + 1
+      }
+      editor.replaceRange(newString, nextLineStart, nextLineStart);
+    }
   }
   cleanSelected(): void {
     const view = this.app.workspace.getActiveViewOfType(MarkdownView);

--- a/main.ts
+++ b/main.ts
@@ -64,13 +64,13 @@ export default class HotkeysPlus extends Plugin {
     this.addCommand({
       id: "duplicate-lines-down",
       name: "Copy line or lines down",
-      callback: () => this.duplicateLines("below"),
+      callback: () => this.duplicateLines("down"),
     });
 
     this.addCommand({
       id: "duplicate-lines-up",
       name: "Copy line or lines up",
-      callback: () => this.duplicateLines("above"),
+      callback: () => this.duplicateLines("up"),
     });
 
     this.addCommand({
@@ -136,15 +136,15 @@ export default class HotkeysPlus extends Plugin {
     }
   }
 
-  duplicateLines(mode: "above" | "below"): void {
+  duplicateLines(mode: "up" | "down"): void {
     const view = this.app.workspace.getActiveViewOfType(MarkdownView);
     if (!view) return;
 
     const editor = view.editor;
     const selectedText = this.getSelectedText(editor);
     const newString = selectedText.content + "\n";
-    
-    if (mode === "below") {
+
+    if (mode === "down") {
       editor.replaceRange(newString, selectedText.start, selectedText.start);
     }
     else {

--- a/main.ts
+++ b/main.ts
@@ -63,13 +63,13 @@ export default class HotkeysPlus extends Plugin {
 
     this.addCommand({
       id: "duplicate-lines-down",
-      name: "Copy line or lines down",
+      name: "Copy line(s) down",
       callback: () => this.duplicateLines("down"),
     });
 
     this.addCommand({
       id: "duplicate-lines-up",
-      name: "Copy line or lines up",
+      name: "Copy line(s) up",
       callback: () => this.duplicateLines("up"),
     });
 

--- a/main.ts
+++ b/main.ts
@@ -144,13 +144,14 @@ export default class HotkeysPlus extends Plugin {
     const selectedText = this.getSelectedText(editor);
     const newString = selectedText.content + "\n";
 
+    console.log(selectedText);
     if (mode === "down") {
       editor.replaceRange(newString, selectedText.start, selectedText.start);
     }
     else {
       const nextLineStart = {
-        ...selectedText.start,
-        line: selectedText.start.line + 1
+        line: selectedText.end.line + 1,
+        ch: 0
       }
       editor.replaceRange(newString, nextLineStart, nextLineStart);
     }

--- a/main.ts
+++ b/main.ts
@@ -141,7 +141,6 @@ export default class HotkeysPlus extends Plugin {
     const selectedText = this.getSelectedText(editor);
     const newString = selectedText.content + "\n";
 
-    console.log(selectedText);
     if (mode === "down") {
       editor.replaceRange(newString, selectedText.start, selectedText.start);
     }

--- a/main.ts
+++ b/main.ts
@@ -5,10 +5,7 @@ import {
 } from "obsidian";
 
 export default class HotkeysPlus extends Plugin {
-  onInit() {
-    console.log('INITITING');
-    console.log('ok')
-   }
+  onInit() { }
 
   onload() {
     console.log("Loading Hotkeys++ plugin");

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "hotkeysplus-obsidian",
   "name": "Hotkeys++",
   "description": "Additional hotkeys to do common things in Obsidian",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "author": "Argentina Ortega Sainz",
   "authorUrl": "",
   "isDesktopOnly": false,


### PR DESCRIPTION
This addresses issue/enhancement #25. A few things to note:
- Let me know if I should change the name of the commands, I'm fine with whatever you all think is best
- Installing this update will cause a current user's existing saved hotkey combination linked to "Duplicate current line or selected lines" to reset back to blank since we're changing the name
- ^ because of this I wasn't sure if the version bump deserved to be a patch or a minor version bump

Thanks for taking a look!


also tagging @NomarCub for visibility